### PR TITLE
Changes nom crate to use no-std

### DIFF
--- a/zipr-core/Cargo.toml
+++ b/zipr-core/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ascii = {version="1.0.0", default-features = false}

--- a/zipr-core/src/data/mod.rs
+++ b/zipr-core/src/data/mod.rs
@@ -6,22 +6,24 @@ mod dos_date;
 mod dos_time;
 mod zip_path;
 
+pub use ascii::AsciiStr;
 use extra_field::ExtraField;
 pub mod extra_field;
 pub use compressed_data::*;
 pub use dos_date::*;
 pub use dos_time::*;
 pub use zip_path::*;
+
 /// End of central directory header
 /// This appears at the end of the file
 /// Mainly used to tell  where the central directory
 /// starts
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq,Default)]
 pub struct EndOfCentralDirectory<'a> {
     pub total_number_records: u16,
     pub size_of_directory: u32,
     pub offset_start_directory: u32,
-    pub comment: &'a str,
+    pub comment: &'a AsciiStr,
 }
 
 /// An entry for a file in the central directory
@@ -43,7 +45,7 @@ pub struct CentralDirectoryEntry<'a> {
     pub relative_offset: u32,
     pub file_name: ZipPath<'a>,
     pub extra_field: ExtraField<'a>,
-    pub comment: &'a str,
+    pub comment: &'a AsciiStr,
 }
 
 /// The local file description

--- a/zipr-nom/Cargo.toml
+++ b/zipr-nom/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flate2 = "1.0"
-nom = "6.0.1"
+miniz_oxide = { version = "0.4.3"}
+nom = { version = "6.0.1", default-features = false }
 zipr-core = {path="../zipr-core"}
+ascii = {version="1.0.0", default-features = false}

--- a/zipr-nom/src/compression/deflate.rs
+++ b/zipr-nom/src/compression/deflate.rs
@@ -1,15 +1,11 @@
-use flate2::bufread::DeflateDecoder;
 use nom::{bytes::complete::take, combinator::map_res, IResult};
-use std::io::prelude::*;
-
+use miniz_oxide::inflate::decompress_to_vec;
+use alloc::vec::Vec;
 /// Parses out the data if it's deflat
 /// uses flate2 internaly
 pub fn parse_deflate<'a>(input: &'a [u8]) -> IResult<&'a [u8], Vec<u8>> {
-    let decode = |bytes: &'a [u8]| -> Result<Vec<u8>, std::io::Error> {
-        let mut decoder = DeflateDecoder::new(bytes);
-        let mut buf = Vec::new();
-        decoder.read_to_end(&mut buf)?;
-        Ok(buf)
+    let decode = |bytes: &'a [u8]| -> Result<Vec<u8>,_> {
+        decompress_to_vec(bytes)
     };
     let (input, result) = map_res(take(input.len()), decode)(input)?;
 

--- a/zipr-nom/src/compression/mod.rs
+++ b/zipr-nom/src/compression/mod.rs
@@ -5,6 +5,7 @@ pub use deflate::parse_deflate;
 use nom::{combinator::into, error::Error, IResult};
 pub use store::parse_store;
 use zipr_core::data::{CompressedData, CompressionMethod};
+use alloc::vec::Vec;
 
 pub fn parse_compressed_data<'a>(
     input: &'a CompressedData<'a>,

--- a/zipr-nom/src/data/ascii_char.rs
+++ b/zipr-nom/src/data/ascii_char.rs
@@ -1,0 +1,14 @@
+use ascii::{AsAsciiStrError, AsciiStr};
+use nom::{IResult, combinator::{eof, map_res, rest}};
+
+fn convert_chars(input: &[u8]) -> Result<&AsciiStr,AsAsciiStrError> {
+    let res = AsciiStr::from_ascii(input)?;
+    Ok(res)
+}
+
+/// Parses the entire input as a asciichar
+pub fn parse_ascii_chars(input: &[u8]) -> IResult<&[u8], &AsciiStr> {
+    let (rem,chars) = map_res(rest,convert_chars)(input)?;
+    let (rem,_ ) = eof(rem)?;
+    Ok((rem,chars))
+}

--- a/zipr-nom/src/data/end_of_central_directory.rs
+++ b/zipr-nom/src/data/end_of_central_directory.rs
@@ -1,15 +1,9 @@
-use std::str::from_utf8;
 use zipr_core::constants::END_OF_CENTRAL_DIRECTORY_HEADER;
 use zipr_core::data::EndOfCentralDirectory;
 
-use nom::{
-    bytes::complete::tag,
-    bytes::complete::take,
-    combinator::{eof, map_res},
-    number::complete::le_u16,
-    number::complete::le_u32,
-    IResult,
-};
+use nom::{IResult, bytes::complete::tag, bytes::complete::take, combinator::{eof, map_parser}, number::complete::le_u16, number::complete::le_u32};
+
+use super::ascii_char::parse_ascii_chars;
 
 /// Parses the end of central directory record exactly
 /// Fails if its not present
@@ -24,7 +18,7 @@ pub fn parse_end_of_central_directory(input: &[u8]) -> IResult<&[u8], EndOfCentr
     let (input, size_of_directory) = le_u32(input)?;
     let (input, offset_start_directory) = le_u32(input)?;
     let (input, comment_length) = le_u16(input)?;
-    let (input, comment) = map_res(take(comment_length), from_utf8)(input)?;
+    let (input, comment) = map_parser(take(comment_length), parse_ascii_chars)(input)?;
     let (input, _eof) = eof(input)?;
     let result = EndOfCentralDirectory {
         total_number_records,

--- a/zipr-nom/src/data/mod.rs
+++ b/zipr-nom/src/data/mod.rs
@@ -3,6 +3,7 @@
 //! Most expect to be given the correct slice as is.
 //! For more user friendly parsers use the higher level functions
 
+mod ascii_char;
 mod central_directory;
 mod compression_method;
 mod end_of_central_directory;

--- a/zipr-nom/src/lib.rs
+++ b/zipr-nom/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std] 
+extern crate alloc;
 mod compression;
 pub mod data;
 mod search;

--- a/zipr-nom/src/search/find_central_directory_entries.rs
+++ b/zipr-nom/src/search/find_central_directory_entries.rs
@@ -3,6 +3,7 @@ use nom::{
     IResult,
 };
 use zipr_core::data::CentralDirectoryEntry;
+use alloc::vec::Vec;
 
 use crate::data::parse_directory_header;
 

--- a/zipr-nom/src/search/find_end_of_central_directory.rs
+++ b/zipr-nom/src/search/find_end_of_central_directory.rs
@@ -23,6 +23,7 @@ pub fn find_end_of_central_directory(input: &[u8]) -> IResult<&[u8], EndOfCentra
 
 #[cfg(test)]
 mod tests {
+    use ascii::AsciiStr;
     use zipr_core::data::EndOfCentralDirectory;
 
     use super::find_end_of_central_directory;
@@ -44,7 +45,7 @@ mod tests {
     #[test]
     fn hello_world_store_with_comment() {
         let input = include_bytes!("../../../assets/hello_world_store_with_comment.zip");
-        let comment = "tricky";
+        let comment = AsciiStr::from_ascii("tricky").unwrap();
         let result = find_end_of_central_directory(input);
         let expected = EndOfCentralDirectory {
             total_number_records: 1,

--- a/zipr-nom/src/search/find_local_file_entries.rs
+++ b/zipr-nom/src/search/find_local_file_entries.rs
@@ -1,5 +1,6 @@
 use nom::IResult;
 use zipr_core::data::{CentralDirectoryEntry, LocalFileEntry};
+use alloc::vec::Vec;
 
 use crate::data::parse_local_file;
 


### PR DESCRIPTION
This allows the parsers to be used in
more relaxed situations now.

Note: we still need an allocator, but
that's a lot less than the full std
infrastructure