### PR TITLE
Adds oem437 conversion functions

### DIFF
--- a/zipr-cli/src/commands/add_files.rs
+++ b/zipr-cli/src/commands/add_files.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use zipr::{
     data::{
-        borrowed::{file::CompressedData, OEM437Str, ZipEntry},
+        borrowed::{file::CompressedData, OEM437Str, OEM437Symbols, ZipEntry},
         CompressionMethod, HostCompatibility, Version, ZipSpecification,
     },
     std::ToPath,
@@ -25,10 +25,9 @@ pub fn add_files<P: AsRef<Path>>(
         let extra_field = zipr::data::borrowed::extra_field::ExtraField::Unknown(&[]);
         let file_modification_time = zipr::data::DosTime::from_u16_unchecked(0);
         let file_modification_date = zipr::data::DosDate::from_u16_unchecked(0);
-        let file_name = zipr::data::borrowed::ZipPath::try_from(OEM437Str::from(
-            path.to_str().unwrap().as_bytes(),
-        ))
-        .unwrap();
+        let symbols = OEM437Symbols::try_from(path.to_str().unwrap())?;
+        let str: OEM437Str = *symbols.as_ref();
+        let file_name = zipr::data::borrowed::ZipPath::try_from(str)?;
 
         let version = Version {
             host: HostCompatibility::MSDOS,

--- a/zipr-cli/src/error.rs
+++ b/zipr-cli/src/error.rs
@@ -1,5 +1,9 @@
 use std::fmt::Display;
-use zipr::{compression::DecompressError, nom::iter::ZipEntryIteratorError};
+use zipr::{
+    compression::DecompressError,
+    data::borrowed::{NotValidOEM437, ZipPathError},
+    nom::iter::ZipEntryIteratorError,
+};
 
 pub type AppResult<T> = Result<T, AppError>;
 #[derive(Debug)]
@@ -8,6 +12,8 @@ pub enum AppError {
     NomError(nom::error::Error<Vec<u8>>),
     ZipIteratorError(ZipEntryIteratorError),
     IOError(std::io::Error),
+    OEM437Error(NotValidOEM437),
+    ZipPathError(ZipPathError),
 }
 
 impl From<std::io::Error> for AppError {
@@ -24,6 +30,18 @@ impl From<ZipEntryIteratorError> for AppError {
 impl From<DecompressError> for AppError {
     fn from(e: DecompressError) -> Self {
         AppError::Decompression(e)
+    }
+}
+
+impl From<NotValidOEM437> for AppError {
+    fn from(e: NotValidOEM437) -> Self {
+        AppError::OEM437Error(e)
+    }
+}
+
+impl From<ZipPathError> for AppError {
+    fn from(e: ZipPathError) -> Self {
+        AppError::ZipPathError(e)
     }
 }
 


### PR DESCRIPTION
This should make it easier to deal with
converting from rust unicode strings
and back.

We don't have functions for dealing with 437
strings, as for the most part you shouldn't
do that anyway